### PR TITLE
Remove bonus `</div>` tag in templates/ai/_sidebar.html

### DIFF
--- a/templates/ai/_sidebar.html
+++ b/templates/ai/_sidebar.html
@@ -8,5 +8,4 @@
       {% include "ai/content/llms-101/_sidebar.html"%}
       {% include "ai/content/_upcoming.html" %}
     </ul>
-  </div>
 </div>


### PR DESCRIPTION
```
[error] templates/ai/_sidebar.html: SyntaxError: Unexpected closing tag "div". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags (12:1)
[error]   10 |     </ul>
[error]   11 |   </div>
[error] > 12 | </div>
[error]      | ^^^^^^
```

via <kbd>npx prettier **/*.html --write</kbd>