### PR TITLE
Remove unexpected closing div tag in templates/base-ai.html

### DIFF
--- a/templates/base-ai.html
+++ b/templates/base-ai.html
@@ -69,9 +69,8 @@
         {% block sidebar %}
             {% include "ai/_sidebar.html" %}
         {% endblock %}
-        </div>
     </div>
     
-     {% block js %}{% endblock %}
+    {% block js %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
```
[error] templates/base-ai.html: SyntaxError: Unexpected closing tag "div". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags (73:5)
[error]   71 |         {% endblock %}
[error]   72 |         </div>
[error] > 73 |     </div>
[error]      |     ^^^^^^
[error]   74 |
[error]   75 |      {% block js %}{% endblock %}
[error]   76 | </body>
```

via <kbd>npx prettier **/*.html --write</kbd>
