### PR TITLE
No self-closing script tags

### DIFF
--- a/templates/base-ai.html
+++ b/templates/base-ai.html
@@ -30,8 +30,8 @@
     <link rel="stylesheet" href="/css/ai.css"/>
     {% endblock %}
     {% block page_js %}
-    <script type="text/javascript" src="/scripts/dark_mode.js"/>
-    <script type="module" src="/scripts/ai.js"/>
+    <script type="text/javascript" src="/scripts/dark_mode.js"></script>
+    <script type="module" src="/scripts/ai.js"></script>
     {% endblock %}
     <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="/img/favicons/apple-touch-icon.png"/>
     <link rel="icon" type="image/png" sizes="196x196" href="/img/favicons/favicon-196x196.png"/>


### PR DESCRIPTION
Per https://www.geeksforgeeks.org/why-dont-self-closing-script-elements-work/, you can't use self-closing `<script />` tags, so I think these were causing some other tags to get swallowed and breaking favicons and other stuff.