### PR TITLE
Update ai-basics _sidebar.html

### DIFF
--- a/templates/ai/content/ai-basics/_sidebar.html
+++ b/templates/ai/content/ai-basics/_sidebar.html
@@ -7,7 +7,7 @@
 <li><a href="/ai/content/ai-basics/index.html#why-are-people-excited-about-llms">Why are people excited about LLMs?</a></li>
 <li><a href="/ai/content/ai-basics/index.html#why-are-people-concerned-about-llms">Why are people concerned about LLMs?</a></li>
 <li><a href="/ai/content/ai-basics/index.html#what-exactly-is-an-llm">What exactly is an LLM?</a></li>
-<li><a href="/ai/content/ai-basics/index.html#what-are-the-pros-cons-of-using-an-llm">What are the pros & cons of using an LLM?</a></li>
+<li><a href="/ai/content/ai-basics/index.html#what-are-the-pros--cons-of-using-an-llm">What are the pros & cons of using an LLM?</a></li>
 <li><a href="/ai/content/ai-basics/index.html#what-new-behaviors-do-llms-unlock">What new behaviors do LLMs unlock?</a></li>
 <li><a href="/ai/content/ai-basics/index.html#what-are-the-components-of-transformer-based-pre-trained-llms">What are the components of Transformer-based, pre-trained LLMs?</a></li>
 <li><a href="/ai/content/ai-basics/index.html#when-i-send-a-transformer-based-llm-a-prompt-what-happens-internally-in-more-technical-terms">When I send a Transformer-based LLM a “prompt”, what happens internally in more technical terms?</a></li></ul></details></li>


### PR DESCRIPTION
This fixes the broken "pros & cons" link in the sidebar.

```sh
git grep -Pn "\-pros-{1,}cons-" | cat

templates/ai/content/ai-basics/_sidebar.html:10:<li><a href="/ai/content/ai-basics/index.html#what-are-the-pros-cons-of-using-an-llm">What are the pros & cons of using an LLM?</a></li>
templates/ai/content/ai-basics/index-content.html:24:<h4 id="what-are-the-pros--cons-of-using-an-llm">What are the pros &amp; cons of using an LLM?</h4>
```